### PR TITLE
push, pop후 refresh 가능 여부에 대한 픽스

### DIFF
--- a/GyroData/Models/FirstVCRelated/FirstModel.swift
+++ b/GyroData/Models/FirstVCRelated/FirstModel.swift
@@ -10,6 +10,7 @@ import Foundation
 class FirstModel {
     //input
     var didTapMeasureButton: (() -> ()) = { }
+    var didReceiveRefreshRequest = { }
     
     //output
     var contentViewModel: FirstListViewModel {
@@ -66,6 +67,10 @@ class FirstModel {
             guard let self = self else { return }
             print("!!!!!!!")
             self.populateData()
+        }
+        
+        didReceiveRefreshRequest = { [weak self] in
+            print("first Model didReceiveRefreshRequest")
         }
     }
     

--- a/GyroData/Models/ThirdVCRelated/ThirdModel.swift
+++ b/GyroData/Models/ThirdVCRelated/ThirdModel.swift
@@ -49,7 +49,7 @@ class ThirdModel {
     // MARK: Bind
     func bind() {
         didTapBackButton = { [weak self] in
-            self?.routeSubject((.close))
+            self?.routeSubject((.closeAndRefresh(.main(.firstViewControllerForRefresh))))
         }
     }
 }

--- a/GyroData/ViewPresentation/Routable.swift
+++ b/GyroData/ViewPresentation/Routable.swift
@@ -24,6 +24,8 @@ protocol Routable {
 //뷰컨트롤러가 dismiss될 수 있다
 protocol SceneDismissable {
     func dismissScene(animated: Bool, completion: (() -> Void)?)
+    func dismissSceneAndRefresh(sceneToRefresh: SceneCategory, animated: Bool, completion: (() -> Void)?)
+    func findSceneToRefresh()
 }
 
 //SceneDismissable이 뷰컨트롤러라면 그냥 일반적인 dismiss를 한다

--- a/GyroData/ViewPresentation/SceneCategory.swift
+++ b/GyroData/ViewPresentation/SceneCategory.swift
@@ -11,11 +11,13 @@ import Foundation
 enum SceneCategory {
     case main(mainScene)
     case detail(detailScene)
-    case close
+    case close //리프래시 등 아무것도 안 하고 닫는 경우
+    indirect case closeAndRefresh(SceneCategory) //이전뷰 리프레시 등 뭔가를 해주기 + 닫기가 되어야 하는 경우
     case alert(AlertDependency)
     
     enum mainScene {
         case firstViewController(context: SceneContext<FirstModel>)
+        case firstViewControllerForRefresh
     }
     
     enum detailScene {

--- a/GyroData/ViewPresentation/ThirdViewControllerRoutable.swift
+++ b/GyroData/ViewPresentation/ThirdViewControllerRoutable.swift
@@ -8,16 +8,40 @@
 import Foundation
 import UIKit
 
-protocol ThirdViewControllerRoutable: Routable {
+protocol ThirdViewControllerRoutable: Routable, SceneDismissable {
     
 }
-
+    
 extension ThirdViewControllerRoutable where Self: ThirdViewController {
     func route(to Scene: SceneCategory) {
         switch Scene {
         case .close:
-            self.navigationController?.popViewController(animated: true)
+            print("just close")
+            self.dismissScene(animated: true, completion: nil)
+        case .closeAndRefresh(let scene):
+            print("close and refresh")
+            self.dismissSceneAndRefresh(sceneToRefresh: scene, animated: true, completion: nil)
         default: break
+        }
+    }
+    
+    func dismissSceneAndRefresh(sceneToRefresh: SceneCategory, animated: Bool, completion: (() -> Void)?) {
+        switch sceneToRefresh {
+        case .main(.firstViewControllerForRefresh):
+            findSceneToRefresh()
+        default: break
+        }
+    }
+    
+    func findSceneToRefresh() {
+        guard let viewControllers = self.navigationController?.viewControllers else { return }
+        for vc in viewControllers {
+            if let firstVC = vc as? FirstViewController {
+                firstVC.model.didReceiveRefreshRequest()
+                self.navigationController?.popToViewController(firstVC, animated: true)
+                print("find scene to refresh call")
+                break
+            }
         }
     }
 }


### PR DESCRIPTION
네비게이션컨트롤러 POP 될 시 FirstVC, FirstModel이 특정한 알림을 받고 그 다음 로직을 진행할 수 있는지에 대한 검증
이를 위해 Routable, SceneCategory, SceneDismissable에 대한 수정 추가
일단 print문 통해 PoP된 목적지(FirstVC)의 모델이 특정한 클로저로 알림을 받을 수 있는지 확인함